### PR TITLE
Add support for dynamic tags and swagger spec url

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -z $SWAGGER_SPEC_URL ]; then
+    echo "You need to set the SWAGGER_SPEC_URL env variable"
+    exit 1
+fi
+
+if [ -z $CI_BUILD_TAG ]; then
+    CI_BUILD_TAG=latest
+fi
+
+sed -i "s|http://petstore.swagger.io/v2/swagger.json|$SWAGGER_SPEC_URL|g" dist/index.html
+docker build -t swagger:$CI_BUILD_TAG .
+


### PR DESCRIPTION
You must provide at least the SWAGGER_SPEC_URL in order to build the image.
If the CI_BUILD_TAG are not provided the latest tag will be used instead.
E.g.
	SWAGGER_SPEC_URL=http://example.com/swagger.json CI_BUILD_TAG=0.1 ./build.sh